### PR TITLE
Migrate from master-slave jargon

### DIFF
--- a/keep/fabfile.py
+++ b/keep/fabfile.py
@@ -43,7 +43,7 @@ def deploy():
         run( 'supervisorctl stop %s' % ( SUPERVISOR_NAME ) )
 
         # Pull latest code from git
-        run( 'git pull origin master' )
+        run( 'git pull origin main' )
 
         # Start up all processes again
         run( 'supervisorctl start all' )


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.